### PR TITLE
Remove code that does nothing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,4 @@
 -- Inject the_funny.lua
 ModLuaFileAppend("data/scripts/streaming_integration/event_utilities.lua", "mods/Copis_Twitchy_Lua/the_funny.lua")
 
--- Save ModTextFile functions past initialization
-Write = ModTextFileSetContent
-Read = ModTextFileGetContent
-
--- Somehow, this works.
-dofile("data/scripts/streaming_integration/event_utilities.lua")
 -- TODO: filter mod setting and persistent flag setting code, look for any vulnerabilities in code


### PR DESCRIPTION
I was wondering what this `dofile` call was for. Turns out that it doesn't do anything and can be removed.